### PR TITLE
Return string updates on marketplace and sold

### DIFF
--- a/marketplace-api.md
+++ b/marketplace-api.md
@@ -40,12 +40,13 @@ Returns 100 sorted names, paginated by an `offset` parameter. For example, `offs
 ```
 {
   "success": boolean,
-  "listings": [
+  "domains": [
     {
       "id": string,
       "amount": string,
-      "asset": string,
+      "name": string,
       "description": string,
+      "watching": string
     },
   ],
 }
@@ -67,13 +68,14 @@ Returns 100 sorted names, paginated by an `offset` parameter. For example, `offs
 ```
 {
   "success": boolean,
-  "listings": [
+  "domains": [
     {
       "id": string,
-      "domain": string,
+      "name": string,
       "amount": string,
       "asset": string,
-      "created_at": datetime,
+      "watching": string,
+      "created_at": datetime
     },
   ],
 }


### PR DESCRIPTION
fixed the documentation on the marketplace and sold command result json after seeing they don't match the real outputs

Note: watching doesn't work, always returns ```None```